### PR TITLE
Use ansible module `copy` instead of shell-command `touch`.

### DIFF
--- a/tasks/configure_servers.yml
+++ b/tasks/configure_servers.yml
@@ -13,10 +13,13 @@
   changed_when: False
 
 - name: Make sure accounts.txt file exists
-  command: touch /etc/boxbackup/bbstored/accounts.txt creates=/etc/boxbackup/bbstored/accounts.txt
-
-- name: Fix accounts.txt permissions
-  file: path=/etc/boxbackup/bbstored/accounts.txt state=file owner=bbstored group=bbstored mode=0600
+  copy:
+    force: false
+    dest: /etc/boxbackup/bbstored/accounts.txt
+    content: ''
+    owner: bbstored
+    group: bbstored
+    mode: 0600
 
 - name: Configure boxbackup server
   template: src={{ item }}.j2 dest=/{{ item }} owner=bbstored group=bbstored mode=0640


### PR DESCRIPTION
This avoids updating the files time-stamp if it already exists. It also
saves the a second execution for fixing permissions.